### PR TITLE
fix new prompt on return

### DIFF
--- a/src/system_command.ts
+++ b/src/system_command.ts
@@ -15,6 +15,7 @@ export interface Callbacks {
 export function execute(command: string, options: Array<string>,
                         env: environment.Environment, callbacks: Callbacks) {
     if(command === null || command === undefined || command === '') {
+      callbacks.close(0, null);
       return;
     }
     var process = child_process.spawn(command, options, {


### PR DESCRIPTION
When a user just hits return without any command, the prompt was hidden,
because there was no command-finished event fired.
